### PR TITLE
feat: support credit hours and permission prerequisite types

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -95,6 +95,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1632,6 +1633,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5229,6 +5231,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5239,6 +5242,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5368,6 +5372,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5624,6 +5629,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6083,6 +6089,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6156,6 +6163,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6572,6 +6580,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6830,6 +6839,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7435,6 +7445,7 @@
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9233,6 +9244,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9242,6 +9254,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10325,6 +10338,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10650,6 +10664,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/Sidebar.jsx
+++ b/client/src/Sidebar.jsx
@@ -34,56 +34,44 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
   console.log(categorizePrereqsRes);
   const requiredPrereqs = categorizePrereqsRes.required;
   const choiceGroupPrereqs = categorizePrereqsRes.choiceGroups;
-  const creditHours = categorizePrereqsRes.creditHours;
-  const permissions = categorizePrereqsRes.permissions;
-  let choiceGroupPrereqsWithStatus = []; // [[{prereqId, status, msg}, ...], [...]]]]
+  let choiceGroupPrereqsWithStatus = []; // [[{prereqId, status, msg}, ...], [...]]]
 
-  const requiredPrereqListWithStatus = requiredPrereqs.map((prereqId) => {
+  // Process required prereqs — items can be strings (courseIds) or objects (credit_hours/permission)
+  const requiredPrereqsWithStatus = requiredPrereqs.map((item) => {
+    if (typeof item === "object") {
+      return { itemType: item.type, ...item };
+    }
+    const prereqId = item;
     const { status, msg } = getEdgeStatus(
       selectedNode.data.prereqs,
       prereqId,
       userGrades[prereqId],
     );
-
-    return { prereqId, status, msg };
+    return { itemType: "course", prereqId, status, msg };
   });
-  console.log(requiredPrereqListWithStatus);
+
+  // Process choice groups — items can also be strings or objects
   choiceGroupPrereqs.forEach((group) => {
-    const res = [];
-    group.forEach((item) => {
-      // Handle credit_hours and permission objects inside OR groups
-      if (typeof item === "object" && item.type === "credit_hours") {
-        res.push({ itemType: "credit_hours", value: item.value, status: "info" });
-        return;
-      }
-      if (typeof item === "object" && item.type === "permission") {
-        res.push({ itemType: "permission", description: item.description, status: "info" });
-        return;
-      }
-      // Handle regular course prereqs
-      const prereqId = item;
-      const { status, msg } = getEdgeStatus(
-        selectedNode.data.prereqs,
-        prereqId,
-        userGrades[prereqId],
-      );
-      if (status !== "error") {
-        res.push({
-          itemType: "course",
+    const res = group
+      .map((item) => {
+        if (typeof item === "object") {
+          return { itemType: item.type, ...item };
+        }
+        const prereqId = item;
+        const { status, msg } = getEdgeStatus(
+          selectedNode.data.prereqs,
           prereqId,
-          status,
-          msg,
-        });
-      }
-    });
-    return choiceGroupPrereqsWithStatus.push(res);
+          userGrades[prereqId],
+        );
+        if (status === "error") return null;
+        return { itemType: "course", prereqId, status, msg };
+      })
+      .filter(Boolean);
+    choiceGroupPrereqsWithStatus.push(res);
   });
 
   const hasAnyPrereqs =
-    requiredPrereqListWithStatus.length > 0 ||
-    choiceGroupPrereqsWithStatus.length > 0 ||
-    creditHours.length > 0 ||
-    permissions.length > 0;
+    requiredPrereqsWithStatus.length > 0 || choiceGroupPrereqsWithStatus.length > 0;
 
   return (
     <div className="flex-1 h-screen shrink-0 overflow-y-auto border-l border-zinc-00 bg-zinc-950 text-zinc-100 shadow-xl">
@@ -128,150 +116,93 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
               </p>
             )}
 
-            {creditHours.length > 0 &&
-              creditHours.map((ch, index) => (
-                <div
-                  key={`ch-${index}`}
-                  className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2"
-                >
-                  <p className="text-xs text-amber-400/70 pb-1">
-                    Credit Hour Requirement
-                  </p>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-amber-200">
-                      Requires {ch.value} credit hours
-                    </span>
-                    <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-400">
-                      info
-                    </span>
-                  </div>
-                </div>
-              ))}
-
-            {permissions.length > 0 &&
-              permissions.map((perm, index) => (
-                <div
-                  key={`perm-${index}`}
-                  className="rounded-lg border border-purple-500/30 bg-purple-500/5 px-3 py-2"
-                >
-                  <p className="text-xs text-purple-400/70 pb-1">
-                    Permission Required
-                  </p>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-purple-200">
-                      {perm.description}
-                    </span>
-                    <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
-                      Info
-                    </span>
-                  </div>
-                </div>
-              ))}
-
-            {(creditHours.length > 0 || permissions.length > 0) &&
-              (requiredPrereqListWithStatus.length > 0 ||
-                choiceGroupPrereqsWithStatus.length > 0) && (
-                <hr className="border-zinc-700/50" />
-              )}
-
-            {requiredPrereqListWithStatus.length !== 0 &&
-              requiredPrereqListWithStatus.map(({ prereqId, status, msg }) => (
-                <div
-                  key={prereqId}
-                  className=" rounded-lg border border-zinc-800/80 bg-zinc-950/40 px-3 py-2"
-                >
-                  <p className="text-xs text-zinc-400 pb-2">{msg}</p>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-zinc-100">
-                      {prereqId}
-                    </span>
-                    <span
-                      className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[status] ??
-                        "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
-                        }`}
-                    >
-                      {status}
-                    </span>
-                  </div>
-                </div>
-              ))}
+            {requiredPrereqsWithStatus.map((item, index) =>
+              renderPrereqItem(item, `req-${index}`),
+            )}
 
             {choiceGroupPrereqsWithStatus.length > 0 && (
               <>
-                <hr className="border-zinc-700/50" />
+                {requiredPrereqsWithStatus.length > 0 && (
+                  <hr className="border-zinc-700/50" />
+                )}
                 {choiceGroupPrereqsWithStatus.map((group, index) => (
                   <div key={index} className="space-y-2">
                     <p className="text-xs text-zinc-400">
                       Satisfy at least one of the following:
                     </p>
-                    {group.map((item, itemIndex) => {
-                      if (item.itemType === "credit_hours") {
-                        return (
-                          <div
-                            key={`ch-or-${itemIndex}`}
-                            className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2"
-                          >
-                            <p className="text-xs text-amber-400/70 pb-1">
-                              Credit Hour Requirement
-                            </p>
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-semibold text-amber-200">
-                                Requires {item.value} credit hours
-                              </span>
-                              <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-400">
-                                info
-                              </span>
-                            </div>
-                          </div>
-                        );
-                      }
-                      if (item.itemType === "permission") {
-                        return (
-                          <div
-                            key={`perm-or-${itemIndex}`}
-                            className="rounded-lg border border-purple-500/30 bg-purple-500/5 px-3 py-2"
-                          >
-                            <p className="text-xs text-purple-400/70 pb-1">
-                              Permission Required
-                            </p>
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-semibold text-purple-200">
-                                {item.description}
-                              </span>
-                              <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
-                                Info
-                              </span>
-                            </div>
-                          </div>
-                        );
-                      }
-                      return (
-                        <div
-                          key={item.prereqId}
-                          className=" rounded-lg border border-zinc-800/80 bg-zinc-950/40 px-3 py-2"
-                        >
-                          <p className="text-xs text-zinc-400 pb-2">{item.msg}</p>
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm font-semibold text-zinc-100">
-                              {item.prereqId}
-                            </span>
-                            <span
-                              className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[item.status] ??
-                                "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
-                                }`}
-                            >
-                              {item.status}
-                            </span>
-                          </div>
-                        </div>
-                      );
-                    })}
+                    {group.map((item, itemIndex) =>
+                      renderPrereqItem(item, `choice-${index}-${itemIndex}`),
+                    )}
                   </div>
                 ))}
               </>
             )}
           </CardContent>
         </Card>
+      </div>
+    </div>
+  );
+}
+
+function renderPrereqItem(item, key) {
+  if (item.itemType === "credit_hours") {
+    return (
+      <div
+        key={key}
+        className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2"
+      >
+        <p className="text-xs text-amber-400/70 pb-1">
+          Credit Hour Requirement
+        </p>
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-amber-200">
+            Requires {item.value} credit hours
+          </span>
+          <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-400">
+            info
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (item.itemType === "permission") {
+    return (
+      <div
+        key={key}
+        className="rounded-lg border border-purple-500/30 bg-purple-500/5 px-3 py-2"
+      >
+        <p className="text-xs text-purple-400/70 pb-1">Permission Required</p>
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-purple-200">
+            {item.description}
+          </span>
+          <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
+            Info
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: course prereq
+  return (
+    <div
+      key={key}
+      className="rounded-lg border border-zinc-800/80 bg-zinc-950/40 px-3 py-2"
+    >
+      <p className="text-xs text-zinc-400 pb-2">{item.msg}</p>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-zinc-100">
+          {item.prereqId}
+        </span>
+        <span
+          className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[item.status] ??
+            "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
+            }`}
+        >
+          {item.status}
+        </span>
       </div>
     </div>
   );

--- a/client/src/Sidebar.jsx
+++ b/client/src/Sidebar.jsx
@@ -150,7 +150,7 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
                       {perm.description}
                     </span>
                     <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
-                      required
+                      Info
                     </span>
                   </div>
                 </div>

--- a/client/src/Sidebar.jsx
+++ b/client/src/Sidebar.jsx
@@ -34,7 +34,9 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
   console.log(categorizePrereqsRes);
   const requiredPrereqs = categorizePrereqsRes.required;
   const choiceGroupPrereqs = categorizePrereqsRes.choiceGroups;
-  let choiceGroupPrereqsWithStatus = []; // [[{prereqId, status, msg}, ...], [...]]]
+  const creditHours = categorizePrereqsRes.creditHours;
+  const permissions = categorizePrereqsRes.permissions;
+  let choiceGroupPrereqsWithStatus = []; // [[{prereqId, status, msg}, ...], [...]]]]
 
   const requiredPrereqListWithStatus = requiredPrereqs.map((prereqId) => {
     const { status, msg } = getEdgeStatus(
@@ -64,6 +66,12 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
     });
     return choiceGroupPrereqsWithStatus.push(res);
   });
+
+  const hasAnyPrereqs =
+    requiredPrereqListWithStatus.length > 0 ||
+    choiceGroupPrereqsWithStatus.length > 0 ||
+    creditHours.length > 0 ||
+    permissions.length > 0;
 
   return (
     <div className="flex-1 h-screen shrink-0 overflow-y-auto border-l border-zinc-00 bg-zinc-950 text-zinc-100 shadow-xl">
@@ -102,6 +110,58 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
+            {!hasAnyPrereqs && (
+              <p className="text-sm text-zinc-500 italic">
+                No prerequisites required
+              </p>
+            )}
+
+            {creditHours.length > 0 &&
+              creditHours.map((ch, index) => (
+                <div
+                  key={`ch-${index}`}
+                  className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2"
+                >
+                  <p className="text-xs text-amber-400/70 pb-1">
+                    Credit Hour Requirement
+                  </p>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-amber-200">
+                      Requires {ch.value} credit hours
+                    </span>
+                    <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-400">
+                      info
+                    </span>
+                  </div>
+                </div>
+              ))}
+
+            {permissions.length > 0 &&
+              permissions.map((perm, index) => (
+                <div
+                  key={`perm-${index}`}
+                  className="rounded-lg border border-purple-500/30 bg-purple-500/5 px-3 py-2"
+                >
+                  <p className="text-xs text-purple-400/70 pb-1">
+                    Permission Required
+                  </p>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-purple-200">
+                      {perm.description}
+                    </span>
+                    <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
+                      required
+                    </span>
+                  </div>
+                </div>
+              ))}
+
+            {(creditHours.length > 0 || permissions.length > 0) &&
+              (requiredPrereqListWithStatus.length > 0 ||
+                choiceGroupPrereqsWithStatus.length > 0) && (
+                <hr className="border-zinc-700/50" />
+              )}
+
             {requiredPrereqListWithStatus.length !== 0 &&
               requiredPrereqListWithStatus.map(({ prereqId, status, msg }) => (
                 <div
@@ -114,10 +174,9 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
                       {prereqId}
                     </span>
                     <span
-                      className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${
-                        statusPillClasses[status] ??
+                      className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[status] ??
                         "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
-                      }`}
+                        }`}
                     >
                       {status}
                     </span>
@@ -144,10 +203,9 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
                             {prereqId}
                           </span>
                           <span
-                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${
-                              statusPillClasses[status] ??
+                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[status] ??
                               "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
-                            }`}
+                              }`}
                           >
                             {status}
                           </span>

--- a/client/src/Sidebar.jsx
+++ b/client/src/Sidebar.jsx
@@ -50,7 +50,18 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
   console.log(requiredPrereqListWithStatus);
   choiceGroupPrereqs.forEach((group) => {
     const res = [];
-    group.forEach((prereqId) => {
+    group.forEach((item) => {
+      // Handle credit_hours and permission objects inside OR groups
+      if (typeof item === "object" && item.type === "credit_hours") {
+        res.push({ itemType: "credit_hours", value: item.value, status: "info" });
+        return;
+      }
+      if (typeof item === "object" && item.type === "permission") {
+        res.push({ itemType: "permission", description: item.description, status: "info" });
+        return;
+      }
+      // Handle regular course prereqs
+      const prereqId = item;
       const { status, msg } = getEdgeStatus(
         selectedNode.data.prereqs,
         prereqId,
@@ -58,6 +69,7 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
       );
       if (status !== "error") {
         res.push({
+          itemType: "course",
           prereqId,
           status,
           msg,
@@ -192,26 +204,68 @@ export function Sidebar({ selectedNode, onChangeGrade, userGrades }) {
                     <p className="text-xs text-zinc-400">
                       Satisfy at least one of the following:
                     </p>
-                    {group.map(({ prereqId, status, msg }) => (
-                      <div
-                        key={prereqId}
-                        className=" rounded-lg border border-zinc-800/80 bg-zinc-950/40 px-3 py-2"
-                      >
-                        <p className="text-xs text-zinc-400 pb-2">{msg}</p>
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm font-semibold text-zinc-100">
-                            {prereqId}
-                          </span>
-                          <span
-                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[status] ??
-                              "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
-                              }`}
+                    {group.map((item, itemIndex) => {
+                      if (item.itemType === "credit_hours") {
+                        return (
+                          <div
+                            key={`ch-or-${itemIndex}`}
+                            className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2"
                           >
-                            {status}
-                          </span>
+                            <p className="text-xs text-amber-400/70 pb-1">
+                              Credit Hour Requirement
+                            </p>
+                            <div className="flex items-center justify-between">
+                              <span className="text-sm font-semibold text-amber-200">
+                                Requires {item.value} credit hours
+                              </span>
+                              <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-400">
+                                info
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      }
+                      if (item.itemType === "permission") {
+                        return (
+                          <div
+                            key={`perm-or-${itemIndex}`}
+                            className="rounded-lg border border-purple-500/30 bg-purple-500/5 px-3 py-2"
+                          >
+                            <p className="text-xs text-purple-400/70 pb-1">
+                              Permission Required
+                            </p>
+                            <div className="flex items-center justify-between">
+                              <span className="text-sm font-semibold text-purple-200">
+                                {item.description}
+                              </span>
+                              <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-purple-400">
+                                Info
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      }
+                      return (
+                        <div
+                          key={item.prereqId}
+                          className=" rounded-lg border border-zinc-800/80 bg-zinc-950/40 px-3 py-2"
+                        >
+                          <p className="text-xs text-zinc-400 pb-2">{item.msg}</p>
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm font-semibold text-zinc-100">
+                              {item.prereqId}
+                            </span>
+                            <span
+                              className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${statusPillClasses[item.status] ??
+                                "text-zinc-200 border-zinc-700/70 bg-zinc-700/20"
+                                }`}
+                            >
+                              {item.status}
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 ))}
               </>

--- a/client/src/coursesData.js
+++ b/client/src/coursesData.js
@@ -875,6 +875,7 @@ export const initialCourses = [
       type: "permission",
       description: "Written permission from the Instructor is required",
     },
+    required: false,
   },
   {
     id: "CS290AH",
@@ -907,6 +908,7 @@ export const initialCourses = [
         { type: "credit_hours", value: 30 },
       ],
     },
+    required: false,
   },
   {
     id: "CS290AK",
@@ -983,6 +985,7 @@ export const initialCourses = [
       type: "permission",
       description: "Under the supervision of a faculty member",
     },
+    required: false,
   },
 
   {

--- a/client/src/utils/categorizePrereqs.js
+++ b/client/src/utils/categorizePrereqs.js
@@ -2,6 +2,8 @@ export function categorizePrereqs(prereqNode) {
   const result = {
     required: [],
     choiceGroups: [], // Array of arrays, e.g., [['STAT160', 'STAT200']]
+    creditHours: [], // Array of { value: number }
+    permissions: [], // Array of { description: string }
   };
 
   if (!prereqNode) return result;
@@ -13,6 +15,19 @@ export function categorizePrereqs(prereqNode) {
         result.required.push(node.courseId);
         return [node.courseId];
       }
+    }
+
+    if (node.type === "credit_hours") {
+      result.creditHours.push({ value: node.value });
+      return [];
+    }
+
+    if (node.type === "permission") {
+      result.permissions.push({
+        description:
+          node.description || node.detail || "Permission required",
+      });
+      return [];
     }
 
     if (node.type === "logic") {

--- a/client/src/utils/categorizePrereqs.js
+++ b/client/src/utils/categorizePrereqs.js
@@ -18,15 +18,19 @@ export function categorizePrereqs(prereqNode) {
     }
 
     if (node.type === "credit_hours") {
+      if (isInsideOr) {
+        return [{ type: "credit_hours", value: node.value }];
+      }
       result.creditHours.push({ value: node.value });
       return [];
     }
 
     if (node.type === "permission") {
-      result.permissions.push({
-        description:
-          node.description || node.detail || "Permission required",
-      });
+      const desc = node.description || node.detail || "Permission required";
+      if (isInsideOr) {
+        return [{ type: "permission", description: desc }];
+      }
+      result.permissions.push({ description: desc });
       return [];
     }
 

--- a/client/src/utils/categorizePrereqs.js
+++ b/client/src/utils/categorizePrereqs.js
@@ -2,8 +2,6 @@ export function categorizePrereqs(prereqNode) {
   const result = {
     required: [],
     choiceGroups: [], // Array of arrays, e.g., [['STAT160', 'STAT200']]
-    creditHours: [], // Array of { value: number }
-    permissions: [], // Array of { description: string }
   };
 
   if (!prereqNode) return result;
@@ -18,19 +16,23 @@ export function categorizePrereqs(prereqNode) {
     }
 
     if (node.type === "credit_hours") {
+      const item = { type: "credit_hours", value: node.value };
       if (isInsideOr) {
-        return [{ type: "credit_hours", value: node.value }];
+        return [item];
       }
-      result.creditHours.push({ value: node.value });
+      result.required.push(item);
       return [];
     }
 
     if (node.type === "permission") {
-      const desc = node.description || node.detail || "Permission required";
+      const item = {
+        type: "permission",
+        description: node.description || node.detail || "Permission required",
+      };
       if (isInsideOr) {
-        return [{ type: "permission", description: desc }];
+        return [item];
       }
-      result.permissions.push({ description: desc });
+      result.required.push(item);
       return [];
     }
 

--- a/client/src/utils/getCourseStatus.js
+++ b/client/src/utils/getCourseStatus.js
@@ -23,6 +23,11 @@ export function evaluatePrereq(node, userGrades) {
     return false;
   }
 
+  // Credit hours and permission are informational — cannot be verified in-app
+  if (node.type === "credit_hours" || node.type === "permission") {
+    return true;
+  }
+
   // RECURSIVE CASE: It is a logic group (AND / OR)
   if (node.type === "logic") {
     if (node.operator === "AND") {


### PR DESCRIPTION
## Summary
Resolves #1 — Displays `credit_hours` and `permission` prerequisite types in the Sidebar.

## Changes
- **[categorizePrereqs.js](cci:7://file:///Users/akshpatel/course-planner/client/src/utils/categorizePrereqs.js:0:0-0:0)** — Extracts `credit_hours` and `permission` nodes
- **[getCourseStatus.js](cci:7://file:///Users/akshpatel/course-planner/client/src/utils/getCourseStatus.js:0:0-0:0)** — Treats both as informational (auto-satisfied)
- **[Sidebar.jsx](cci:7://file:///Users/akshpatel/course-planner/client/src/Sidebar.jsx:0:0-0:0)** — Renders amber cards for credit hours, purple cards for permissions
- **[coursesData.js](cci:7://file:///Users/akshpatel/course-planner/client/src/coursesData.js:0:0-0:0)** — Uncommented 3 sample courses (CS290AG, CS290AJ, CS390AR)
